### PR TITLE
Animation lifecycle managed by Scene

### DIFF
--- a/src/h3d/Camera.hx
+++ b/src/h3d/Camera.hx
@@ -174,20 +174,6 @@ class Camera {
 			target.set(0, 0, 0);
 			follow.pos.localToGlobal(pos);
 			follow.target.localToGlobal(target);
-			// Animate FOV
-			if( follow.pos.name != null ) {
-				var p = follow.pos;
-				while( p != null ) {
-					if( p.currentAnimation != null ) {
-						var v = p.currentAnimation.getPropValue(follow.pos.name, "FOVY");
-						if( v != null ) {
-							fovY = v;
-							break;
-						}
-					}
-					p = p.parent;
-				}
-			}
 		}
 		makeCameraMatrix(mcam);
 		makeFrustumMatrix(mproj);

--- a/src/h3d/anim/Animation.hx
+++ b/src/h3d/anim/Animation.hx
@@ -121,6 +121,7 @@ class Animation implements hxd.impl.Serializable {
 		return a;
 	}
 
+	@:allow(h3d.scene.Scene.tryAnimation)
 	function initInstance() {
 		isInstance = true;
 	}
@@ -133,6 +134,13 @@ class Animation implements hxd.impl.Serializable {
 		a.bind(base);
 		a.initInstance();
 		return a;
+	}
+
+	public function createUnboundInstance() {
+		final instance = this.clone();
+		instance.objects = [for(o in this.objects) o.clone()];
+		instance.initInstance();
+		return instance;
 	}
 
 	/**

--- a/src/h3d/scene/Animation.hx
+++ b/src/h3d/scene/Animation.hx
@@ -1,0 +1,75 @@
+package h3d.scene;
+
+import h3d.scene.SceneStorage.EntityId;
+
+/**
+    TODO - Future consolidation of animation state:
+    - h3d.anim.Animation should have one backing state
+    - Backing state should include necessary fields for entity association
+**/
+@:forward(id)
+abstract Animation(AnimationRow) from AnimationRow {
+    public var currentAnimation(get, never): h3d.anim.Animation;
+    inline function get_currentAnimation() return this.state.match(Remove) ? null : this.currentAnimation;
+
+    // Functions to register animations
+    public static function scheduleAnimation(storage:SceneStorage, id:EntityId, a:h3d.anim.Animation): Animation {
+        final row = storage.objectAnimationStorage.fetchRow(id);
+        row.state = Play;
+        row.currentAnimation = a.createUnboundInstance();
+        return row;
+    }
+
+    public static function switchToAnimation(storage:SceneStorage, id:EntityId, a:h3d.anim.Animation) {
+        return storage.objectAnimationStorage.fetchRow(id).currentAnimation = a;
+    }
+
+    public static function stopAnimation(storage:SceneStorage, id: EntityId) {
+        storage.objectAnimationStorage.fetchRow(id).state = Remove;
+    }
+}
+
+class AnimationRow {
+	public final id: AnimationId;
+
+	public var currentAnimation: h3d.anim.Animation = null;
+	public var state: AnimationState = Removed;
+
+	public function new(id: AnimationId) {
+		this.id = id;
+    }
+}
+
+enum AnimationState {
+    Play;
+    Playing;
+    Remove;
+    Removed;
+}
+
+abstract AnimationId(EntityId) from EntityId to EntityId {}
+
+class AnimationStorage {
+	final storage = new hds.Map<AnimationId, AnimationRow>();
+
+	public function new() {}
+
+	public function allocateRow(eid: h3d.scene.SceneStorage.EntityId): AnimationId {
+		final row = new AnimationRow(eid);
+		this.storage.set(eid, row);
+
+		return eid;
+	}
+
+	public function deallocateRow(id: AnimationId) {
+		return this.storage.remove(id);
+	}
+
+	public function fetchRow(id: AnimationId) {
+		return this.storage.get(id);
+	}
+
+	public function reset() {
+		this.storage.clear();
+	}
+}

--- a/src/h3d/scene/SceneStorage.hx
+++ b/src/h3d/scene/SceneStorage.hx
@@ -19,7 +19,7 @@ class SceneStorage {
     public final worldStorage = new h3d.scene.World.WorldStorage();
 
     public final relativePositionStorage = new h3d.scene.Object.RelativePositionStorage();
-    public final animationStorage = new h3d.scene.Object.AnimationStorage();
+    public final objectAnimationStorage = new h3d.scene.Animation.AnimationStorage();
 
 	public function new() {}
 	
@@ -43,12 +43,12 @@ class SceneStorage {
         return this.relativePositionStorage.fetchRow(id);
     }
     
-    public function insertAnimation(eid: EntityId) {
-        return this.animationStorage.allocateRow(eid);
+    public function insertObjectAnimation(eid: EntityId) {
+        return this.objectAnimationStorage.allocateRow(eid);
     }
 
-    public function selectAnimation(id: h3d.scene.Object.AnimationId) {
-        return this.animationStorage.fetchRow(id);
+    public function selectObjectAnimation(id: h3d.scene.Animation.AnimationId) {
+        return this.objectAnimationStorage.fetchRow(id);
     }
     
     public function insertMesh(eid: EntityId, primitive: h3d.prim.Primitive, materials: Array<h3d.mat.Material>): h3d.scene.Mesh.MeshId {

--- a/src/hds/SeqIntMap.hx
+++ b/src/hds/SeqIntMap.hx
@@ -1,4 +1,6 @@
-package hxd.fmt.gltf;
+package hds;
+
+import hxd.Debug;
 
 typedef MapVal = { ints:Array<Int>, index:Int};
 

--- a/src/hxd/Debug.hx
+++ b/src/hxd/Debug.hx
@@ -1,0 +1,9 @@
+package hxd;
+
+class Debug {
+    public static function assert(cond, ?message) {
+        if (!cond) {
+            throw (message != null) ? message : "assert failed";
+        }
+    }
+}

--- a/src/hxd/fmt/gltf/HMDOut.hx
+++ b/src/hxd/fmt/gltf/HMDOut.hx
@@ -4,9 +4,10 @@ import h3d.Quat;
 import h3d.Vector;
 import h3d.col.Bounds;
 import hxd.fmt.hmd.Data;
+import hxd.Debug;
+import hds.SeqIntMap;
 
 import hxd.fmt.gltf.Data;
-
 
 class HMDOut {
 

--- a/src/hxd/fmt/gltf/Parser.hx
+++ b/src/hxd/fmt/gltf/Parser.hx
@@ -1,5 +1,6 @@
 package hxd.fmt.gltf;
 
+import hxd.Debug;
 import haxe.crypto.Base64;
 import h3d.Quat;
 import h3d.Vector;
@@ -218,7 +219,7 @@ class Parser {
 				var dataStart = buf.uri.indexOf(";base64,") + 8;
 				buffBytes = Base64.decode(buf.uri.substr(dataStart));
 			} else {
-				buffBytes = sys.io.File.getBytes(localDir + buf.uri);
+				#if sys buffBytes = sys.io.File.getBytes(localDir + buf.uri); #end
 			}
 			// TODO: better URI handling
 			if (buffBytes.length < buf.byteLength) {

--- a/src/hxd/fmt/obj/HMDOut.hx
+++ b/src/hxd/fmt/obj/HMDOut.hx
@@ -1,8 +1,8 @@
 package hxd.fmt.obj;
 
 import hxd.fmt.hmd.Data;
-import Debug;
-
+import hxd.Debug;
+import hds.SeqIntMap;
 
 class HMDOut {
 	final filePath: String;
@@ -10,7 +10,7 @@ class HMDOut {
 	var obj: hxd.fmt.obj.Parser;
 	var mats: Map<String, Parser.Material>;
 
-	var vertSeqMap = new util.SeqIntMap();
+	var vertSeqMap = new SeqIntMap();
 	var vertData = [];
 	var normData = [];
 	var texData = [];


### PR DESCRIPTION
Animations could be set/unset on Objects arbitrarily before. Now
addition and removals feel immediate, but are managed by the Scene.
This is a partial step towards making sense of animation lifecycles.

* h3d.scene.Object.Animation is now h3d.scene.AnimationRow
* Object Animation API are commands for Scene animation management
* Camera FOVY animation is now managed by the scene